### PR TITLE
fix: address text wrapping in Safari

### DIFF
--- a/src/app/[theme]/Project.tsx
+++ b/src/app/[theme]/Project.tsx
@@ -53,7 +53,7 @@ export function ProjectPreview({
           </div>
         )}
         {project.links && project.links.length > 0 && (
-          <div className="flex gap-x-2 divide-x divide-zinc-800 dark:divide-white text-sm text-nowrap">
+          <div className="flex gap-x-2 divide-x divide-zinc-800 dark:divide-white text-sm">
             {project.links.map((link) =>
               link.url && link.title ? (
                 <a
@@ -62,7 +62,8 @@ export function ProjectPreview({
                   href={link.url}
                   target="_blank"
                 >
-                  {link.title}
+                  {/* Replace spaces with non-breaking space to avoid wrapping in Safari */}
+                  {link.title.replace(/\s/g, '\u00A0')}
                 </a>
               ) : null,
             )}


### PR DESCRIPTION
## Before:
<img width="1205" alt="before" src="https://github.com/user-attachments/assets/cf6072b7-9f19-4a0f-a050-cefa08ee1b21">

## After:
<img width="1203" alt="after" src="https://github.com/user-attachments/assets/3f26046e-3c14-441e-a866-48d68491d019">
