### PR TITLE
[00056] Add GitHub Actions CI Workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+on:
+  pull_request:
+  push:
+    branches: [main]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      # Sanity vars satisfy assertValue() checks in env.ts; types are committed so no
+      # actual Sanity requests are made during next build.
+      NEXT_PUBLIC_SANITY_PROJECT_ID: placeholder
+      NEXT_PUBLIC_SANITY_DATASET: production
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      # Run next build directly to skip prebuild (sanity typegen); types are committed.
+      - run: pnpm exec next build
+      - run: pnpm run lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      # Sanity vars satisfy assertValue() checks in env.ts; types are committed so no
-      # actual Sanity requests are made during next build.
-      NEXT_PUBLIC_SANITY_PROJECT_ID: placeholder
-      NEXT_PUBLIC_SANITY_DATASET: production
+      NEXT_PUBLIC_SANITY_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_SANITY_PROJECT_ID }}
+      NEXT_PUBLIC_SANITY_DATASET: ${{ secrets.NEXT_PUBLIC_SANITY_DATASET }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -18,9 +17,8 @@ jobs:
           version: 9
       - uses: actions/setup-node@v4
         with:
-          node-version-file: .nvmrc
+          node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      # Run next build directly to skip prebuild (sanity typegen); types are committed.
       - run: pnpm exec next build
       - run: pnpm run lint


### PR DESCRIPTION
Added `.github/workflows/ci.yml` to run lint and build on every PR and push to `main`. The workflow uses pnpm v9 and Node 22, skips the `prebuild` typegen step (since `src/sanity/types.ts` and `src/sanity/schema.json` are committed), and uses GitHub secrets for `NEXT_PUBLIC_SANITY_PROJECT_ID`, `NEXT_PUBLIC_SANITY_DATASET`, and `SENTRY_AUTH_TOKEN`. All three secrets are configured in the repository settings.

## API Changes

None.

## Files Modified

- `.github/workflows/ci.yml` — new CI workflow (checkout, pnpm install, next build, lint) using repository secrets

---

**Commits:**
- `2a5ea74` [00056] Update CI workflow to use GitHub secrets
- `8039784` [00056] Add GitHub Actions CI workflow