### PR TITLE
[00057] Configure Renovate Automerge and Grouping

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,14 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
+  "extends": ["config:recommended"],
+  "schedule": ["before 9am on Monday"],
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "all non-major dependencies",
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeStrategy": "squash"
+    }
   ]
 }


### PR DESCRIPTION
Updated `renovate.json` to group all minor and patch dependency updates into a single PR ("all non-major dependencies") and enable automerge via squash once CI passes. Added a Monday-morning schedule so dependency updates are batched weekly rather than arriving ad-hoc.

## API Changes

None.

## Files Modified

- `renovate.json` — Added `schedule`, `packageRules` with grouping and automerge configuration

---
- 204359e [00057] Configure Renovate grouping and automerge for minor/patch updates