### PR TITLE
[00067] Enable Renovate Dependency Dashboard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
+  "dependency-dashboard": true,
   "schedule": ["before 9am on Monday"],
   "packageRules": [
     {


### PR DESCRIPTION
## Summary

Added `"dependency-dashboard": true` to `renovate.json`. Renovate will now create and maintain a "Dependency Dashboard" GitHub issue that lists all pending updates, rate-limited PRs, and ignored packages, giving full visibility into what Renovate is managing.

## API Changes

None.

## Files Modified

- `renovate.json` — Added `dependency-dashboard: true` field

---

**Commits:**
- `3bf0d7a` [00067] Enable Renovate Dependency Dashboard