### PR TITLE
[00063] Migrate @vercel/flags to the flags package (v4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@sanity/vision": "^3.99.0",
     "@sentry/nextjs": "^8.55.2",
     "@vercel/analytics": "^1.6.1",
-    "@vercel/flags": "^3.0.0",
+    "flags": "^4.0.0",
     "@vercel/speed-insights": "^1.3.1",
     "@vercel/toolbar": "^0.1.41",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,9 +29,6 @@ importers:
       '@vercel/analytics':
         specifier: ^1.6.1
         version: 1.6.1(next@15.5.18(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
-      '@vercel/flags':
-        specifier: ^3.0.0
-        version: 3.1.1(@opentelemetry/api@1.9.1)(next@15.5.18(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@vercel/speed-insights':
         specifier: ^1.3.1
         version: 1.3.1(next@15.5.18(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
@@ -44,6 +41,9 @@ importers:
       dayjs:
         specifier: ^1.11.20
         version: 1.11.20
+      flags:
+        specifier: ^4.0.0
+        version: 4.0.6(@opentelemetry/api@1.9.1)(next@15.5.18(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       import-in-the-middle:
         specifier: ^1.15.0
         version: 1.15.0
@@ -2819,27 +2819,6 @@ packages:
   '@vercel/edge@1.3.1':
     resolution: {integrity: sha512-k0tKWeYEWOv6qU6+Z8+hv2Nt/u3vFHRZdB0uvwE0DxoddU/5kWX/Chu8F6ojvqmRlnZwuX/7kyZFVeCP6DxqBg==}
 
-  '@vercel/flags@3.1.1':
-    resolution: {integrity: sha512-JM0xXRCHvN5wiSr9C2u6PSbXMnqN/0IXyNEOob6UYWB70vBWVLUKM96wgSuj6orRzRTowItmja2RTYyRvVhuQg==}
-    deprecated: This package has been renamed to flags. It offers the same functionality under a new name. Please follow the upgrade guide https://github.com/vercel/flags/blob/main/packages/flags/guides/upgrade-to-v4.md
-    peerDependencies:
-      '@opentelemetry/api': ^1.7.0
-      '@sveltejs/kit': '*'
-      next: '*'
-      react: '*'
-      react-dom: '*'
-    peerDependenciesMeta:
-      '@opentelemetry/api':
-        optional: true
-      '@sveltejs/kit':
-        optional: true
-      next:
-        optional: true
-      react:
-        optional: true
-      react-dom:
-        optional: true
-
   '@vercel/microfrontends@1.3.0':
     resolution: {integrity: sha512-7hvza7+osdfowUllyDthk3QerhoU/8kQgr9QNsIxOJQxpbpwGlN3mMNvYG7CaPB41kQutY6D7StCiOg0E0xGFg==}
     hasBin: true
@@ -4197,6 +4176,26 @@ packages:
   find-yarn-workspace-root2@1.2.16:
     resolution: {integrity: sha512-hr6hb1w8ePMpPVUK39S4RlwJzi+xPLuVuG8XlwXU3KD5Yn3qgBWVfy3AzNlDhWvE1EORCE65/Qm26rFQt3VLVA==}
 
+  flags@4.0.6:
+    resolution: {integrity: sha512-8Rz/5L8Gkl2+LmlV2gOXx3iJNTYDooa8eGvshFev9nrXtrcvsXa5z/DXdtElHvN15psnSHg+r51lYHge2rCASw==}
+    peerDependencies:
+      '@opentelemetry/api': ^1.7.0
+      '@sveltejs/kit': '*'
+      next: '*'
+      react: '*'
+      react-dom: '*'
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   flat-cache@4.0.1:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
@@ -4837,8 +4836,8 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
-  jose@5.2.1:
-    resolution: {integrity: sha512-qiaQhtQRw6YrOaOj0v59h3R6hUY9NvxBmmnMfKemkqYmBB0tEc97NbLP7ix44VP5p9/0YHG8Vyhzuo5YBNwviA==}
+  jose@5.10.0:
+    resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -10288,16 +10287,6 @@ snapshots:
 
   '@vercel/edge@1.3.1': {}
 
-  '@vercel/flags@3.1.1(@opentelemetry/api@1.9.1)(next@15.5.18(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
-    dependencies:
-      '@edge-runtime/cookies': 5.0.2
-      jose: 5.2.1
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.1
-      next: 15.5.18(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
-
   '@vercel/microfrontends@1.3.0(@vercel/analytics@1.6.1(next@15.5.18(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0))(@vercel/speed-insights@1.3.1(next@15.5.18(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0))(next@15.5.18(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@6.4.2(@types/node@22.19.19)(jiti@2.7.0)(terser@5.47.1)(yaml@2.9.0))':
     dependencies:
       '@next/env': 15.1.6
@@ -11844,6 +11833,16 @@ snapshots:
       micromatch: 4.0.8
       pkg-dir: 4.2.0
 
+  flags@4.0.6(@opentelemetry/api@1.9.1)(next@15.5.18(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+    dependencies:
+      '@edge-runtime/cookies': 5.0.2
+      jose: 5.10.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      next: 15.5.18(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+
   flat-cache@4.0.1:
     dependencies:
       flatted: 3.4.2
@@ -12489,7 +12488,7 @@ snapshots:
 
   jiti@2.7.0: {}
 
-  jose@5.2.1: {}
+  jose@5.10.0: {}
 
   js-tokens@4.0.0: {}
 

--- a/src/app/.well-known/vercel/flags/route.ts
+++ b/src/app/.well-known/vercel/flags/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse, type NextRequest } from 'next/server'
-import { verifyAccess, type ApiData } from '@vercel/flags'
+import { verifyAccess, version, type ApiData } from 'flags'
 import { fetchGateIdsCached } from '../../../../statsig'
 import { cache } from 'react'
 
@@ -13,8 +13,8 @@ export async function GET(request: NextRequest) {
     definitions[gateId] = createGateDefinitionCached(gateId)
   })
 
-  return NextResponse.json<ApiData>({
-    definitions,
+  return NextResponse.json<ApiData>({ definitions }, {
+    headers: { 'x-flags-sdk-version': version },
   })
 }
 

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -1,5 +1,5 @@
 import { cache } from 'react'
-import { flag } from '@vercel/flags/next'
+import { flag } from 'flags/next'
 import { checkGateCached } from '@/statsig'
 
 export const getShowProjects = cache(


### PR DESCRIPTION
## Changes

Migrated from the deprecated `@vercel/flags` package (v3) to the renamed `flags` package (v4). Updated all import paths across the codebase and added the required `x-flags-sdk-version` response header to the flags discovery endpoint for Flags Explorer compatibility.

## API Changes

None — all public flag exports (`getShowProjects`, `getShowNavigation`) retain their signatures.

## Files Modified

- **`package.json`** — Replaced `"@vercel/flags": "^3.0.0"` with `"flags": "^4.0.0"`
- **`pnpm-lock.yaml`** — Updated lockfile to reflect package replacement
- **`src/flags.ts`** — Changed import from `@vercel/flags/next` to `flags/next`
- **`src/app/.well-known/vercel/flags/route.ts`** — Changed import from `@vercel/flags` to `flags`, added `version` import, added `x-flags-sdk-version` response header

---
- 47581ab [00063] Migrate @vercel/flags to flags package (v4)